### PR TITLE
Select service nodes based on measurement

### DIFF
--- a/client.go
+++ b/client.go
@@ -130,6 +130,7 @@ func (c *TunaSessionClient) Listen(addrsRe *nkn.StringArray) error {
 		ReverseIPFilter:           *c.config.TunaIPFilter,
 		DownloadGeoDB:             c.config.TunaDownloadGeoDB,
 		GeoDBPath:                 c.config.TunaGeoDBPath,
+		MeasureBandwidth:          c.config.TunaMeasureBandwidth,
 		DialTimeout:               int32(dialTimeout),
 	}
 

--- a/config.go
+++ b/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	TunaIPFilter           *geo.IPFilter
 	TunaDownloadGeoDB      bool
 	TunaGeoDBPath          string
+	TunaMeasureBandwidth   bool
 	SessionConfig          *ncp.Config
 }
 
@@ -30,6 +31,7 @@ var defaultConfig = Config{
 	TunaIPFilter:           nil,
 	TunaDownloadGeoDB:      false,
 	TunaGeoDBPath:          "",
+	TunaMeasureBandwidth:   false,
 	SessionConfig:          nil,
 }
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/nknorg/ncp-go v1.0.3
 	github.com/nknorg/nkn-sdk-go v1.3.4-0.20201020100539-187d9201bdfe
 	github.com/nknorg/nkn/v2 v2.0.6
-	github.com/nknorg/tuna v0.0.0-20201023035110-a24b4bc3a850
+	github.com/nknorg/tuna v0.0.0-20201220063940-28671a066e93
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 )

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/nknorg/ncp-go v1.0.3
 	github.com/nknorg/nkn-sdk-go v1.3.4-0.20201020100539-187d9201bdfe
 	github.com/nknorg/nkn/v2 v2.0.6
-	github.com/nknorg/tuna v0.0.0-20201220063940-28671a066e93
+	github.com/nknorg/tuna v0.0.0-20210115061015-fd21a9fb27ad
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 )

--- a/go.sum
+++ b/go.sum
@@ -254,8 +254,8 @@ github.com/nknorg/nnet v0.0.0-20200521002812-357d1b11179f h1:JvDKr6D9LdnsdScND+8
 github.com/nknorg/nnet v0.0.0-20200521002812-357d1b11179f/go.mod h1:4DHEQEMhlRGIKGSyhATdjeusdqaHafDatadtpeHBpvI=
 github.com/nknorg/portmapper v0.0.0-20200114081049-1c03cdccc283 h1:uS3/DvxCbi0zZau66ggQAgEjyGmql2mj77UQFgumq1I=
 github.com/nknorg/portmapper v0.0.0-20200114081049-1c03cdccc283/go.mod h1:dL4PQJ4670oTO6LqvkjrBQEkD+iMiOYjlKRBBw55Csg=
-github.com/nknorg/tuna v0.0.0-20201023035110-a24b4bc3a850 h1:JwIUuddZmOKEEFuFZHjCZJGBBwLWBTpb1bgniZSxRtU=
-github.com/nknorg/tuna v0.0.0-20201023035110-a24b4bc3a850/go.mod h1:msaNwV8TVzZ0XV2nRIO+JRifflSyYASqcOPfUn7mk7E=
+github.com/nknorg/tuna v0.0.0-20201220063940-28671a066e93 h1:OPLYgaFTn0Yljc231uscxSsANQzJ+0ENcvYRM3E2db0=
+github.com/nknorg/tuna v0.0.0-20201220063940-28671a066e93/go.mod h1:msaNwV8TVzZ0XV2nRIO+JRifflSyYASqcOPfUn7mk7E=
 github.com/nrdcg/auroradns v1.0.1/go.mod h1:y4pc0i9QXYlFCWrhWrUSIETnZgrf4KuwjDIWmmXo3JI=
 github.com/nrdcg/dnspod-go v0.4.0/go.mod h1:vZSoFSFeQVm2gWLMkyX61LZ8HI3BaqtHZWgPTGKr6KQ=
 github.com/nrdcg/goinwx v0.7.0/go.mod h1:4tKJOCi/1lTxuw9/yB2Ez0aojwtUCSkckjc22eALpqE=

--- a/go.sum
+++ b/go.sum
@@ -254,8 +254,8 @@ github.com/nknorg/nnet v0.0.0-20200521002812-357d1b11179f h1:JvDKr6D9LdnsdScND+8
 github.com/nknorg/nnet v0.0.0-20200521002812-357d1b11179f/go.mod h1:4DHEQEMhlRGIKGSyhATdjeusdqaHafDatadtpeHBpvI=
 github.com/nknorg/portmapper v0.0.0-20200114081049-1c03cdccc283 h1:uS3/DvxCbi0zZau66ggQAgEjyGmql2mj77UQFgumq1I=
 github.com/nknorg/portmapper v0.0.0-20200114081049-1c03cdccc283/go.mod h1:dL4PQJ4670oTO6LqvkjrBQEkD+iMiOYjlKRBBw55Csg=
-github.com/nknorg/tuna v0.0.0-20201220063940-28671a066e93 h1:OPLYgaFTn0Yljc231uscxSsANQzJ+0ENcvYRM3E2db0=
-github.com/nknorg/tuna v0.0.0-20201220063940-28671a066e93/go.mod h1:msaNwV8TVzZ0XV2nRIO+JRifflSyYASqcOPfUn7mk7E=
+github.com/nknorg/tuna v0.0.0-20210115061015-fd21a9fb27ad h1:C5PZUVnhrO4fVf2oBOEBMDAWy3qW482l89tlSwBNzXQ=
+github.com/nknorg/tuna v0.0.0-20210115061015-fd21a9fb27ad/go.mod h1:msaNwV8TVzZ0XV2nRIO+JRifflSyYASqcOPfUn7mk7E=
 github.com/nrdcg/auroradns v1.0.1/go.mod h1:y4pc0i9QXYlFCWrhWrUSIETnZgrf4KuwjDIWmmXo3JI=
 github.com/nrdcg/dnspod-go v0.4.0/go.mod h1:vZSoFSFeQVm2gWLMkyX61LZ8HI3BaqtHZWgPTGKr6KQ=
 github.com/nrdcg/goinwx v0.7.0/go.mod h1:4tKJOCi/1lTxuw9/yB2Ez0aojwtUCSkckjc22eALpqE=

--- a/message.go
+++ b/message.go
@@ -128,7 +128,7 @@ func readMessage(conn *Conn, maxMsgSize uint32) ([]byte, error) {
 
 	msgSize := binary.LittleEndian.Uint32(msgSizeBuf)
 	if msgSize > maxMsgSize {
-		return nil, errors.New("invalid message size")
+		return nil, fmt.Errorf("invalid message size %d, should be no greater than %d", msgSize, maxMsgSize)
 	}
 
 	buf := make([]byte, msgSize)


### PR DESCRIPTION
By default latency will be used, with the option to enable bandwidth measurement