### PR TITLE
Add session close status in PubAddrs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,14 +4,14 @@ go 1.20
 
 require (
 	github.com/imdario/mergo v0.3.13
-	github.com/nknorg/ncp-go v1.0.5
+	github.com/nknorg/ncp-go v1.0.6-0.20230228002512-f4cd1740bebd
 	github.com/nknorg/nkn-sdk-go v1.4.3
 	github.com/nknorg/nkn/v2 v2.1.8
 	github.com/nknorg/nkngomobile v0.0.0-20220615081414-671ad1afdfa9
 	github.com/nknorg/tuna v0.0.0-20230307074911-ced36707f273
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
-	google.golang.org/protobuf v1.27.1
+	google.golang.org/protobuf v1.28.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -124,7 +124,6 @@ github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:x
 github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrUpVNzEA03Pprs=
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
-github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
@@ -245,8 +244,8 @@ github.com/nknorg/encrypted-stream v1.0.1 h1:lyWouCwUY3WUOfYaoez0wNEudsZJ3qc9Knx
 github.com/nknorg/encrypted-stream v1.0.1/go.mod h1:VXJDhlUoF3uJSFLwIWnRLkiX5QPFB3E8oe2EUBwPoU0=
 github.com/nknorg/go-nat v1.0.1/go.mod h1:dblX1Ac2j08rTUGs5CKCAfjHGN5eDFhbeqt2rccSP3Y=
 github.com/nknorg/mockconn-go v0.0.0-20230125231524-d664e728352a/go.mod h1:/SvBORYxt9wlm8ZbaEFEri6ooOSDcU3ovU0L2eRRdS4=
-github.com/nknorg/ncp-go v1.0.5 h1:alJjq6bi6tRwUAAv932FIfE/R3S7DRR0pgXOgBXNHAk=
-github.com/nknorg/ncp-go v1.0.5/go.mod h1:ze88qf5e9/DBXSOaJPL2Caa0IbdZJLzESAFM1S7mGwg=
+github.com/nknorg/ncp-go v1.0.6-0.20230228002512-f4cd1740bebd h1:ZAXKeWKjkbS9QQhrOCNYEbNIIF7tOXfDVHQijvEY6VE=
+github.com/nknorg/ncp-go v1.0.6-0.20230228002512-f4cd1740bebd/go.mod h1:T7ThlxmBjVIv3Ll3gJOHbQTuAFN3ZCYWvbux6JOX5wQ=
 github.com/nknorg/nkn-sdk-go v1.4.3 h1:TIrmB0NoFHImKp0V5pYNJWbJE9dhULq/WUykxl15FI0=
 github.com/nknorg/nkn-sdk-go v1.4.3/go.mod h1:LbLboeVQuxSGfqyKu/iVGZfMFOLvrvwGU1Qde3/XfAg=
 github.com/nknorg/nkn/v2 v2.1.8 h1:h25rqQ0E8CvlN8Jm4zF6CBBLgwdoSS7HHdrU4ZYcmjA=
@@ -594,8 +593,8 @@ google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
-google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
+google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/message.go
+++ b/message.go
@@ -6,10 +6,11 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/nknorg/nkngomobile"
 	"io"
 	"regexp"
 	"time"
+
+	"github.com/nknorg/nkngomobile"
 
 	"github.com/nknorg/nkn/v2/crypto/ed25519"
 	"golang.org/x/crypto/nacl/box"
@@ -21,10 +22,13 @@ const (
 	maxAddrSize            = 512
 	maxSessionMetadataSize = 1024
 	maxSessionMsgOverhead  = 1024
+
+	ActionGetPubAddr = "getPubAddr"
 )
 
 type Request struct {
-	Action string `json:"action"`
+	Action    string `json:"action"`
+	SessionID []byte `json:"sessionID"`
 }
 
 type PubAddr struct {
@@ -35,7 +39,8 @@ type PubAddr struct {
 }
 
 type PubAddrs struct {
-	Addrs []*PubAddr `json:"addrs"`
+	Addrs         []*PubAddr `json:"addrs"`
+	SessionClosed bool       `json:"sessionClosed"`
 }
 
 func (c *TunaSessionClient) getOrComputeSharedKey(remotePublicKey []byte) (*[sharedKeySize]byte, error) {

--- a/tests/pub.go
+++ b/tests/pub.go
@@ -1,4 +1,4 @@
-package test
+package tests
 
 import (
 	"encoding/binary"

--- a/tests/reconnect_test.go
+++ b/tests/reconnect_test.go
@@ -1,4 +1,4 @@
-package test
+package tests
 
 import (
 	"testing"

--- a/tests/tunasession.go
+++ b/tests/tunasession.go
@@ -1,4 +1,4 @@
-package test
+package tests
 
 import (
 	"fmt"


### PR DESCRIPTION
1. Use ncp.session.GetContext to follow ncp.session status;
2. Add session close status in PubAddrs to follow the listener's session status.