### PR TITLE
Cache public addresses for re-dialing.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,11 +10,13 @@ require (
 	github.com/nknorg/nkngomobile v0.0.0-20220615081414-671ad1afdfa9
 	github.com/nknorg/tuna v0.0.0-20230328054959-0bc6eb5bf369
 	github.com/patrickmn/go-cache v2.1.0+incompatible
+	github.com/stretchr/testify v1.8.1
 	golang.org/x/crypto v0.7.0
 	google.golang.org/protobuf v1.29.1
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
@@ -26,8 +28,10 @@ require (
 	github.com/oschwald/maxminddb-golang v1.6.0 // indirect
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rdegges/go-ipify v0.0.0-20150526035502-2d94a6a86c40 // indirect
 	github.com/xtaci/smux v2.0.1+incompatible // indirect
 	golang.org/x/mobile v0.0.0-20230301163155-e0f57694e12c // indirect
 	golang.org/x/sys v0.6.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,7 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.29.1 h1:7QBf+IK2gx70Ap/hDsOmam3GE0v9HicjfEdAxE62UoM=
 google.golang.org/protobuf v1.29.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/message.go
+++ b/message.go
@@ -38,6 +38,10 @@ type PubAddr struct {
 	OutPrice string `json:"outPrice,omitempty"`
 }
 
+func (pa *PubAddr) String() string {
+	return fmt.Sprintf("%v:%v", pa.IP, pa.Port)
+}
+
 type PubAddrs struct {
 	Addrs         []*PubAddr `json:"addrs"`
 	SessionClosed bool       `json:"sessionClosed"`

--- a/tests/cachepubaddr_test.go
+++ b/tests/cachepubaddr_test.go
@@ -1,0 +1,55 @@
+package tests
+
+import (
+	"log"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// go test -v -run=TestCachePubAddr
+func TestCachePubAddr(t *testing.T) {
+	ch := make(chan string, 1)
+
+	go func() {
+		StartTunaTcpListener(numTcpListener, ch)
+	}()
+
+	waitfor(ch, listening)
+	time.Sleep(10 * time.Second) // still wait for tuna exits establish connections.
+
+	go func() {
+		log.Printf("tcp dialer start now...")
+
+		acc, wal, err := CreateAccountAndWallet(seedHex)
+		require.Nil(t, err)
+		mc, err := CreateMultiClient(acc, dialerId, 2)
+		require.Nil(t, err)
+
+		tunaSess, err := CreateTunaSession(acc, wal, mc, numTcpListener)
+		require.Nil(t, err)
+
+		diaConfig := CreateDialConfig(5000)
+		ncpSess1, err := tunaSess.DialWithConfig(remoteAddr, diaConfig)
+		require.Nil(t, err)
+		ch <- dialed
+
+		mc.Close() // close nkn multi-client
+		ncpSess2, err := tunaSess.DialWithConfig(remoteAddr, diaConfig)
+		require.Nil(t, err)
+		ch <- dialed
+		log.Printf("tcp dialer dialed up even nkn multi-client closed, because it uses cached pubAddrs...")
+
+		tunaSess.CloseOneConn(ncpSess1, "0") // close connection 0
+		tunaSess.CloseOneConn(ncpSess2, "0") // close conenction 0
+
+		time.Sleep(time.Second)
+		_, err = tunaSess.DialWithConfig(remoteAddr, diaConfig) // should not dial up successfully.
+		require.NotNil(t, err)
+
+		ch <- end
+	}()
+
+	waitfor(ch, end)
+}

--- a/tests/config.go
+++ b/tests/config.go
@@ -4,7 +4,7 @@ import "time"
 
 const (
 	bytesToSend    = 10 << 10
-	numTcpListener = 4
+	numTcpListener = 2
 	numUdpListener = 1
 	numUdpDialers  = 4
 	bufSize        = 100


### PR DESCRIPTION
1. Add a new method getCachedPubAddrs to TunaSessionClient.
2. Call getCachedPubAddrs at the beginning of getPubAddrsFromRemote to retrieve the cached address first.
3. Need to export getCachedPubAddrs and sessionID before running the test case because the case is in a different package.