### PR TITLE
Add verbose to config and check ip and port before go routine

### DIFF
--- a/client.go
+++ b/client.go
@@ -579,6 +579,13 @@ func (c *TunaSessionClient) DialWithConfig(remoteAddr string, config *nkn.DialCo
 
 	var wg sync.WaitGroup
 	for i := range pubAddrs.Addrs {
+		if pubAddrs.Addrs[i] == nil || pubAddrs.Addrs[i].IP == "" || pubAddrs.Addrs[i].Port == 0 {
+			if c.config.Verbose {
+				log.Printf("Tuna session pubAddrs %v doesn't have valid ip %v port %v", i, pubAddrs.Addrs[i].IP, pubAddrs.Addrs[i].Port)
+			}
+			continue
+		}
+
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()

--- a/config.go
+++ b/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	ReconnectInterval      int // millisecond
 	UDPRecvBufferSize      int // UDP user data receive buffer size, bytes
 	MaxUdpDatagramBuffered int // Maximum udp datagrams can be buffered. It works with UDPRecvBufferSize together go decide if a datagram is buffered.
+	Verbose                bool
 }
 
 var defaultConfig = Config{
@@ -52,6 +53,7 @@ var defaultConfig = Config{
 	ReconnectInterval:      2000,
 	UDPRecvBufferSize:      1 << 20, // 1 mega bytes
 	MaxUdpDatagramBuffered: 1024,
+	Verbose:                false,
 }
 
 func DefaultConfig() *Config {


### PR DESCRIPTION
1. Add `verbose` parameter to config;
2. Check if `IP` and `Port` are valid before creating connection go routine.